### PR TITLE
Release steam pipes only if they exist

### DIFF
--- a/SAM.API/Client.cs
+++ b/SAM.API/Client.cs
@@ -91,10 +91,14 @@ namespace SAM.API
 
         ~Client()
         {
-            if (this.SteamClient != null)
+            if (this.SteamClient != null && this._Pipe > 0)
             {
-                this.SteamClient.ReleaseUser(this._Pipe, this._User);
-                this._User = 0;
+                if (this._User > 0)
+                {
+                    this.SteamClient.ReleaseUser(this._Pipe, this._User);
+                    this._User = 0;
+                }
+                
                 this.SteamClient.ReleaseSteamPipe(this._Pipe);
                 this._Pipe = 0;
             }


### PR DESCRIPTION
If CreateSteamPipe or ConnectToGlobalUser fail, when Client is destructed, steamclient will throw an assertion because it tries to dispose invalid.