### PR TITLE
Locally cache game logos

### DIFF
--- a/SAM.Picker/LICENSE.txt
+++ b/SAM.Picker/LICENSE.txt
@@ -1,6 +1,7 @@
 zlib License
 
 Copyright (c) 2019 Rick (rick 'at' gibbed 'dot' us)
+Copyright (c) 2018-2019 Jan Klass (kissaki@posteo.de)
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages


### PR DESCRIPTION
Fixes #65
Fixes #80

Before this change all game logos for all games in the steam library were
downloaded on every launch of GamePicker.
With some Steam libraries exceeding thousands of games, and with how
rarely we expect them to actually change upstream, this is an unnecessary
load on the steam media CDN, the network bandwidth and download size,
and it takes time to download them.

This change introduces a local image cache located in the applications
local appdata path.
As the default local appdata path includes the programs version, but
these images do not change with GamePicker program versions, we store
the cache in the parent version-agnostic folder.

This does not include a refresh/update image mechanism.