### PR TITLE
Set image bit depth to 24 bits

### DIFF
--- a/SAM.Game/Manager.Designer.cs
+++ b/SAM.Game/Manager.Designer.cs
@@ -115,7 +115,7 @@
             // 
             // _AchievementImageList
             // 
-            this._AchievementImageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
+            this._AchievementImageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth24Bit;
             this._AchievementImageList.ImageSize = new System.Drawing.Size(64, 64);
             this._AchievementImageList.TransparentColor = System.Drawing.Color.Transparent;
             // 

--- a/SAM.Picker/GamePicker.Designer.cs
+++ b/SAM.Picker/GamePicker.Designer.cs
@@ -67,7 +67,7 @@
             // 
             // _LogoImageList
             // 
-            this._LogoImageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth8Bit;
+            this._LogoImageList.ColorDepth = System.Windows.Forms.ColorDepth.Depth24Bit;
             this._LogoImageList.ImageSize = new System.Drawing.Size(184, 69);
             this._LogoImageList.TransparentColor = System.Drawing.Color.Transparent;
             // 


### PR DESCRIPTION
Displays the logo and achievement images with the correct bit depth.

Fixes #356