### PR TITLE
A new column "Global Progress" percentage per achivement

### DIFF
--- a/SAM.API/Wrappers/SteamUserStats013.cs
+++ b/SAM.API/Wrappers/SteamUserStats013.cs
@@ -160,6 +160,32 @@ namespace SAM.API.Wrappers
         }
         #endregion
 
+        #region GetGlobalAchievementPercantage
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private delegate bool NativeRequestGlobalAchievementPercentages(IntPtr self);
+
+        public bool RequestGlobalAchievementPercentages()
+        {
+            var call = this.GetFunction<NativeRequestGlobalAchievementPercentages>(this.Functions.RequestGlobalAchievementPercentages);
+            return call(this.ObjectAddress);
+        }
+        #endregion
+
+        #region GetAchievementAchievedPercent
+        [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+        private delegate bool NativeGetAchievementAchievedPercent(
+            IntPtr self,                      
+            [MarshalAs(UnmanagedType.LPStr)] string achievementName,
+            out float percent                 
+        );
+
+        public bool GetAchievementAchievedPercent(string achievementName, out float percent)
+        {
+            var call = this.GetFunction<NativeGetAchievementAchievedPercent>(this.Functions.GetAchievementAchievedPercent);
+            return call(this.ObjectAddress, achievementName, out percent);
+        }
+        #endregion
+
         #region StoreStats
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         [return: MarshalAs(UnmanagedType.I1)]

--- a/SAM.Game/Manager.Designer.cs
+++ b/SAM.Game/Manager.Designer.cs
@@ -48,6 +48,7 @@
             this._AchievementNameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._AchievementDescriptionColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._AchievementUnlockTimeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._AchievementGlobarProgressColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._AchievementsToolStrip = new System.Windows.Forms.ToolStrip();
             this._LockAllButton = new System.Windows.Forms.ToolStripButton();
             this._InvertAllButton = new System.Windows.Forms.ToolStripButton();
@@ -89,7 +90,7 @@
             this._ResetButton});
             this._MainToolStrip.Location = new System.Drawing.Point(0, 0);
             this._MainToolStrip.Name = "_MainToolStrip";
-            this._MainToolStrip.Size = new System.Drawing.Size(712, 25);
+            this._MainToolStrip.Size = new System.Drawing.Size(1172, 25);
             this._MainToolStrip.TabIndex = 1;
             // 
             // _StoreButton
@@ -139,7 +140,7 @@
             this._DownloadStatusLabel});
             this._MainStatusStrip.Location = new System.Drawing.Point(0, 370);
             this._MainStatusStrip.Name = "_MainStatusStrip";
-            this._MainStatusStrip.Size = new System.Drawing.Size(712, 22);
+            this._MainStatusStrip.Size = new System.Drawing.Size(1172, 22);
             this._MainStatusStrip.TabIndex = 4;
             // 
             // _CountryStatusLabel
@@ -150,7 +151,7 @@
             // _GameStatusLabel
             // 
             this._GameStatusLabel.Name = "_GameStatusLabel";
-            this._GameStatusLabel.Size = new System.Drawing.Size(555, 17);
+            this._GameStatusLabel.Size = new System.Drawing.Size(1157, 17);
             this._GameStatusLabel.Spring = true;
             this._GameStatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -177,7 +178,7 @@
             this._MainTabControl.Location = new System.Drawing.Point(8, 33);
             this._MainTabControl.Name = "_MainTabControl";
             this._MainTabControl.SelectedIndex = 0;
-            this._MainTabControl.Size = new System.Drawing.Size(696, 334);
+            this._MainTabControl.Size = new System.Drawing.Size(1156, 334);
             this._MainTabControl.TabIndex = 5;
             // 
             // _AchievementsTabPage
@@ -187,7 +188,7 @@
             this._AchievementsTabPage.Location = new System.Drawing.Point(4, 22);
             this._AchievementsTabPage.Name = "_AchievementsTabPage";
             this._AchievementsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this._AchievementsTabPage.Size = new System.Drawing.Size(688, 308);
+            this._AchievementsTabPage.Size = new System.Drawing.Size(1148, 308);
             this._AchievementsTabPage.TabIndex = 0;
             this._AchievementsTabPage.Text = "Achievements";
             this._AchievementsTabPage.UseVisualStyleBackColor = true;
@@ -201,7 +202,8 @@
             this._AchievementListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this._AchievementNameColumnHeader,
             this._AchievementDescriptionColumnHeader,
-            this._AchievementUnlockTimeColumnHeader});
+            this._AchievementUnlockTimeColumnHeader,
+            this._AchievementGlobarProgressColumnHeader});
             this._AchievementListView.Dock = System.Windows.Forms.DockStyle.Fill;
             this._AchievementListView.ForeColor = System.Drawing.Color.White;
             this._AchievementListView.FullRowSelect = true;
@@ -210,7 +212,7 @@
             this._AchievementListView.LargeImageList = this._AchievementImageList;
             this._AchievementListView.Location = new System.Drawing.Point(3, 28);
             this._AchievementListView.Name = "_AchievementListView";
-            this._AchievementListView.Size = new System.Drawing.Size(682, 277);
+            this._AchievementListView.Size = new System.Drawing.Size(1142, 277);
             this._AchievementListView.SmallImageList = this._AchievementImageList;
             this._AchievementListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this._AchievementListView.TabIndex = 4;
@@ -233,6 +235,11 @@
             this._AchievementUnlockTimeColumnHeader.Text = "Unlock Time";
             this._AchievementUnlockTimeColumnHeader.Width = 160;
             // 
+            // _AchievementGlobarProgressColumnHeader
+            // 
+            this._AchievementGlobarProgressColumnHeader.Text = "Global Progress";
+            this._AchievementGlobarProgressColumnHeader.Width = 97;
+            // 
             // _AchievementsToolStrip
             // 
             this._AchievementsToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -248,7 +255,7 @@
             this._MatchingStringTextBox});
             this._AchievementsToolStrip.Location = new System.Drawing.Point(3, 3);
             this._AchievementsToolStrip.Name = "_AchievementsToolStrip";
-            this._AchievementsToolStrip.Size = new System.Drawing.Size(682, 25);
+            this._AchievementsToolStrip.Size = new System.Drawing.Size(1142, 25);
             this._AchievementsToolStrip.TabIndex = 5;
             // 
             // _LockAllButton
@@ -333,7 +340,7 @@
             this._StatisticsTabPage.Location = new System.Drawing.Point(4, 22);
             this._StatisticsTabPage.Name = "_StatisticsTabPage";
             this._StatisticsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this._StatisticsTabPage.Size = new System.Drawing.Size(688, 308);
+            this._StatisticsTabPage.Size = new System.Drawing.Size(1148, 308);
             this._StatisticsTabPage.TabIndex = 1;
             this._StatisticsTabPage.Text = "Statistics";
             this._StatisticsTabPage.UseVisualStyleBackColor = true;
@@ -371,7 +378,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(712, 392);
+            this.ClientSize = new System.Drawing.Size(1172, 392);
             this.Controls.Add(this._MainToolStrip);
             this.Controls.Add(this._MainTabControl);
             this.Controls.Add(this._MainStatusStrip);
@@ -426,5 +433,6 @@
         private System.Windows.Forms.ToolStripTextBox _MatchingStringTextBox;
         private System.Windows.Forms.ColumnHeader _AchievementUnlockTimeColumnHeader;
         private System.Windows.Forms.CheckBox _EnableStatsEditingCheckBox;
+        private System.Windows.Forms.ColumnHeader _AchievementGlobarProgressColumnHeader;
     }
 }

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -359,6 +359,8 @@ namespace SAM.Game
                 return;
             }
 
+            this._SteamClient.SteamUserStats.RequestGlobalAchievementPercentages();
+
             try
             {
                 this.GetAchievements();
@@ -431,9 +433,7 @@ namespace SAM.Game
 
             bool wantLocked = this._DisplayLockedOnlyButton.Checked == true;
             bool wantUnlocked = this._DisplayUnlockedOnlyButton.Checked == true;
-
-            this._SteamClient.SteamUserStats.RequestGlobalAchievementPercentages();
-            
+                        
             foreach (var def in this._AchievementDefinitions)
             {
                 if (string.IsNullOrEmpty(def.Id) == true)
@@ -461,8 +461,12 @@ namespace SAM.Game
 
                 if (textSearch != null)
                 {
-                    if (def.Name.IndexOf(textSearch, StringComparison.OrdinalIgnoreCase) < 0 ||
-                        def.Description.IndexOf(textSearch, StringComparison.OrdinalIgnoreCase) < 0)
+                    string[] searchTerms = textSearch.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    bool nameMatches = searchTerms.All(term => def.Name.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0);
+                    bool descriptionMatches = searchTerms.All(term => def.Description.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0);
+
+                    if (!nameMatches && !descriptionMatches)
                     {
                         continue;
                     }

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -28,7 +28,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Security.Cryptography;
 using System.Windows.Forms;
 using static SAM.Game.InvariantShorthand;
 using APITypes = SAM.API.Types;
@@ -253,91 +252,91 @@ namespace SAM.Game
                 switch (type)
                 {
                     case APITypes.UserStatType.Invalid:
-                        {
-                            break;
-                        }
+                    {
+                        break;
+                    }
 
                     case APITypes.UserStatType.Integer:
-                        {
-                            var id = stat["name"].AsString("");
-                            string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
+                    {
+                        var id = stat["name"].AsString("");
+                        string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
 
-                            this._StatDefinitions.Add(new Stats.IntegerStatDefinition()
-                            {
-                                Id = stat["name"].AsString(""),
-                                DisplayName = name,
-                                MinValue = stat["min"].AsInteger(int.MinValue),
-                                MaxValue = stat["max"].AsInteger(int.MaxValue),
-                                MaxChange = stat["maxchange"].AsInteger(0),
-                                IncrementOnly = stat["incrementonly"].AsBoolean(false),
-                                SetByTrustedGameServer = stat["bSetByTrustedGS"].AsBoolean(false),
-                                DefaultValue = stat["default"].AsInteger(0),
-                                Permission = stat["permission"].AsInteger(0),
-                            });
-                            break;
-                        }
+                        this._StatDefinitions.Add(new Stats.IntegerStatDefinition()
+                        {
+                            Id = stat["name"].AsString(""),
+                            DisplayName = name,
+                            MinValue = stat["min"].AsInteger(int.MinValue),
+                            MaxValue = stat["max"].AsInteger(int.MaxValue),
+                            MaxChange = stat["maxchange"].AsInteger(0),
+                            IncrementOnly = stat["incrementonly"].AsBoolean(false),
+                            SetByTrustedGameServer = stat["bSetByTrustedGS"].AsBoolean(false),
+                            DefaultValue = stat["default"].AsInteger(0),
+                            Permission = stat["permission"].AsInteger(0),
+                        });
+                        break;
+                    }
 
                     case APITypes.UserStatType.Float:
                     case APITypes.UserStatType.AverageRate:
-                        {
-                            var id = stat["name"].AsString("");
-                            string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
+                    {
+                        var id = stat["name"].AsString("");
+                        string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
 
-                            this._StatDefinitions.Add(new Stats.FloatStatDefinition()
-                            {
-                                Id = stat["name"].AsString(""),
-                                DisplayName = name,
-                                MinValue = stat["min"].AsFloat(float.MinValue),
-                                MaxValue = stat["max"].AsFloat(float.MaxValue),
-                                MaxChange = stat["maxchange"].AsFloat(0.0f),
-                                IncrementOnly = stat["incrementonly"].AsBoolean(false),
-                                DefaultValue = stat["default"].AsFloat(0.0f),
-                                Permission = stat["permission"].AsInteger(0),
-                            });
-                            break;
-                        }
+                        this._StatDefinitions.Add(new Stats.FloatStatDefinition()
+                        {
+                            Id = stat["name"].AsString(""),
+                            DisplayName = name,
+                            MinValue = stat["min"].AsFloat(float.MinValue),
+                            MaxValue = stat["max"].AsFloat(float.MaxValue),
+                            MaxChange = stat["maxchange"].AsFloat(0.0f),
+                            IncrementOnly = stat["incrementonly"].AsBoolean(false),
+                            DefaultValue = stat["default"].AsFloat(0.0f),
+                            Permission = stat["permission"].AsInteger(0),
+                        });
+                        break;
+                    }
 
                     case APITypes.UserStatType.Achievements:
                     case APITypes.UserStatType.GroupAchievements:
+                    {
+                        if (stat.Children != null)
                         {
-                            if (stat.Children != null)
+                            foreach (var bits in stat.Children.Where(
+                                b => string.Compare(b.Name, "bits", StringComparison.InvariantCultureIgnoreCase) == 0))
                             {
-                                foreach (var bits in stat.Children.Where(
-                                    b => string.Compare(b.Name, "bits", StringComparison.InvariantCultureIgnoreCase) == 0))
+                                if (bits.Valid == false ||
+                                    bits.Children == null)
                                 {
-                                    if (bits.Valid == false ||
-                                        bits.Children == null)
-                                    {
-                                        continue;
-                                    }
+                                    continue;
+                                }
 
-                                    foreach (var bit in bits.Children)
-                                    {
-                                        string id = bit["name"].AsString("");
-                                        string name = GetLocalizedString(bit["display"]["name"], currentLanguage, id);
-                                        string desc = GetLocalizedString(bit["display"]["desc"], currentLanguage, "");
+                                foreach (var bit in bits.Children)
+                                {
+                                    string id = bit["name"].AsString("");
+                                    string name = GetLocalizedString(bit["display"]["name"], currentLanguage, id);
+                                    string desc = GetLocalizedString(bit["display"]["desc"], currentLanguage, "");
 
-                                        this._AchievementDefinitions.Add(new()
-                                        {
-                                            Id = id,
-                                            Name = name,
-                                            Description = desc,
-                                            IconNormal = bit["display"]["icon"].AsString(""),
-                                            IconLocked = bit["display"]["icon_gray"].AsString(""),
-                                            IsHidden = bit["display"]["hidden"].AsBoolean(false),
-                                            Permission = bit["permission"].AsInteger(0),
-                                        });
-                                    }
+                                    this._AchievementDefinitions.Add(new()
+                                    {
+                                        Id = id,
+                                        Name = name,
+                                        Description = desc,
+                                        IconNormal = bit["display"]["icon"].AsString(""),
+                                        IconLocked = bit["display"]["icon_gray"].AsString(""),
+                                        IsHidden = bit["display"]["hidden"].AsBoolean(false),
+                                        Permission = bit["permission"].AsInteger(0),
+                                    });
                                 }
                             }
-
-                            break;
                         }
+
+                        break;
+                    }
 
                     default:
-                        {
-                            throw new InvalidOperationException("invalid stat type");
-                        }
+                    {
+                        throw new InvalidOperationException("invalid stat type");
+                    }
                 }
             }
 
@@ -433,11 +432,8 @@ namespace SAM.Game
             bool wantLocked = this._DisplayLockedOnlyButton.Checked == true;
             bool wantUnlocked = this._DisplayUnlockedOnlyButton.Checked == true;
 
-            if (this._SteamClient.SteamUserStats.RequestGlobalAchievementPercentages())
-            {
-                
-            }
-
+            this._SteamClient.SteamUserStats.RequestGlobalAchievementPercentages();
+            
             foreach (var def in this._AchievementDefinitions)
             {
                 if (string.IsNullOrEmpty(def.Id) == true)
@@ -470,7 +466,7 @@ namespace SAM.Game
                     {
                         continue;
                     }
-                }
+                }                
 
                 _SteamClient.SteamUserStats.GetAchievementAchievedPercent(def.Id, out float percentage);
 
@@ -486,7 +482,7 @@ namespace SAM.Game
                     Permission = def.Permission,
                     Name = def.Name,
                     Description = def.Description,
-                    Progress = percentage
+                    Progress = percentage,
                 };
 
                 ListViewItem item = new()

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -28,6 +28,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using System.Windows.Forms;
 using static SAM.Game.InvariantShorthand;
 using APITypes = SAM.API.Types;
@@ -252,91 +253,91 @@ namespace SAM.Game
                 switch (type)
                 {
                     case APITypes.UserStatType.Invalid:
-                    {
-                        break;
-                    }
+                        {
+                            break;
+                        }
 
                     case APITypes.UserStatType.Integer:
-                    {
-                        var id = stat["name"].AsString("");
-                        string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
-
-                        this._StatDefinitions.Add(new Stats.IntegerStatDefinition()
                         {
-                            Id = stat["name"].AsString(""),
-                            DisplayName = name,
-                            MinValue = stat["min"].AsInteger(int.MinValue),
-                            MaxValue = stat["max"].AsInteger(int.MaxValue),
-                            MaxChange = stat["maxchange"].AsInteger(0),
-                            IncrementOnly = stat["incrementonly"].AsBoolean(false),
-                            SetByTrustedGameServer = stat["bSetByTrustedGS"].AsBoolean(false),
-                            DefaultValue = stat["default"].AsInteger(0),
-                            Permission = stat["permission"].AsInteger(0),
-                        });
-                        break;
-                    }
+                            var id = stat["name"].AsString("");
+                            string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
+
+                            this._StatDefinitions.Add(new Stats.IntegerStatDefinition()
+                            {
+                                Id = stat["name"].AsString(""),
+                                DisplayName = name,
+                                MinValue = stat["min"].AsInteger(int.MinValue),
+                                MaxValue = stat["max"].AsInteger(int.MaxValue),
+                                MaxChange = stat["maxchange"].AsInteger(0),
+                                IncrementOnly = stat["incrementonly"].AsBoolean(false),
+                                SetByTrustedGameServer = stat["bSetByTrustedGS"].AsBoolean(false),
+                                DefaultValue = stat["default"].AsInteger(0),
+                                Permission = stat["permission"].AsInteger(0),
+                            });
+                            break;
+                        }
 
                     case APITypes.UserStatType.Float:
                     case APITypes.UserStatType.AverageRate:
-                    {
-                        var id = stat["name"].AsString("");
-                        string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
-
-                        this._StatDefinitions.Add(new Stats.FloatStatDefinition()
                         {
-                            Id = stat["name"].AsString(""),
-                            DisplayName = name,
-                            MinValue = stat["min"].AsFloat(float.MinValue),
-                            MaxValue = stat["max"].AsFloat(float.MaxValue),
-                            MaxChange = stat["maxchange"].AsFloat(0.0f),
-                            IncrementOnly = stat["incrementonly"].AsBoolean(false),
-                            DefaultValue = stat["default"].AsFloat(0.0f),
-                            Permission = stat["permission"].AsInteger(0),
-                        });
-                        break;
-                    }
+                            var id = stat["name"].AsString("");
+                            string name = GetLocalizedString(stat["display"]["name"], currentLanguage, id);
+
+                            this._StatDefinitions.Add(new Stats.FloatStatDefinition()
+                            {
+                                Id = stat["name"].AsString(""),
+                                DisplayName = name,
+                                MinValue = stat["min"].AsFloat(float.MinValue),
+                                MaxValue = stat["max"].AsFloat(float.MaxValue),
+                                MaxChange = stat["maxchange"].AsFloat(0.0f),
+                                IncrementOnly = stat["incrementonly"].AsBoolean(false),
+                                DefaultValue = stat["default"].AsFloat(0.0f),
+                                Permission = stat["permission"].AsInteger(0),
+                            });
+                            break;
+                        }
 
                     case APITypes.UserStatType.Achievements:
                     case APITypes.UserStatType.GroupAchievements:
-                    {
-                        if (stat.Children != null)
                         {
-                            foreach (var bits in stat.Children.Where(
-                                b => string.Compare(b.Name, "bits", StringComparison.InvariantCultureIgnoreCase) == 0))
+                            if (stat.Children != null)
                             {
-                                if (bits.Valid == false ||
-                                    bits.Children == null)
+                                foreach (var bits in stat.Children.Where(
+                                    b => string.Compare(b.Name, "bits", StringComparison.InvariantCultureIgnoreCase) == 0))
                                 {
-                                    continue;
-                                }
-
-                                foreach (var bit in bits.Children)
-                                {
-                                    string id = bit["name"].AsString("");
-                                    string name = GetLocalizedString(bit["display"]["name"], currentLanguage, id);
-                                    string desc = GetLocalizedString(bit["display"]["desc"], currentLanguage, "");
-
-                                    this._AchievementDefinitions.Add(new()
+                                    if (bits.Valid == false ||
+                                        bits.Children == null)
                                     {
-                                        Id = id,
-                                        Name = name,
-                                        Description = desc,
-                                        IconNormal = bit["display"]["icon"].AsString(""),
-                                        IconLocked = bit["display"]["icon_gray"].AsString(""),
-                                        IsHidden = bit["display"]["hidden"].AsBoolean(false),
-                                        Permission = bit["permission"].AsInteger(0),
-                                    });
+                                        continue;
+                                    }
+
+                                    foreach (var bit in bits.Children)
+                                    {
+                                        string id = bit["name"].AsString("");
+                                        string name = GetLocalizedString(bit["display"]["name"], currentLanguage, id);
+                                        string desc = GetLocalizedString(bit["display"]["desc"], currentLanguage, "");
+
+                                        this._AchievementDefinitions.Add(new()
+                                        {
+                                            Id = id,
+                                            Name = name,
+                                            Description = desc,
+                                            IconNormal = bit["display"]["icon"].AsString(""),
+                                            IconLocked = bit["display"]["icon_gray"].AsString(""),
+                                            IsHidden = bit["display"]["hidden"].AsBoolean(false),
+                                            Permission = bit["permission"].AsInteger(0),
+                                        });
+                                    }
                                 }
                             }
+
+                            break;
                         }
 
-                        break;
-                    }
-
                     default:
-                    {
-                        throw new InvalidOperationException("invalid stat type");
-                    }
+                        {
+                            throw new InvalidOperationException("invalid stat type");
+                        }
                 }
             }
 
@@ -432,6 +433,11 @@ namespace SAM.Game
             bool wantLocked = this._DisplayLockedOnlyButton.Checked == true;
             bool wantUnlocked = this._DisplayUnlockedOnlyButton.Checked == true;
 
+            if (this._SteamClient.SteamUserStats.RequestGlobalAchievementPercentages())
+            {
+                
+            }
+
             foreach (var def in this._AchievementDefinitions)
             {
                 if (string.IsNullOrEmpty(def.Id) == true)
@@ -466,6 +472,8 @@ namespace SAM.Game
                     }
                 }
 
+                _SteamClient.SteamUserStats.GetAchievementAchievedPercent(def.Id, out float percentage);
+
                 Stats.AchievementInfo info = new()
                 {
                     Id = def.Id,
@@ -478,6 +486,7 @@ namespace SAM.Game
                     Permission = def.Permission,
                     Name = def.Name,
                     Description = def.Description,
+                    Progress = percentage
                 };
 
                 ListViewItem item = new()
@@ -503,6 +512,8 @@ namespace SAM.Game
                 item.SubItems.Add(info.UnlockTime.HasValue == true
                     ? info.UnlockTime.Value.ToString()
                     : "");
+
+                item.SubItems.Add((percentage > 0 ? $"{percentage}%" : "Error").ToString());
 
                 info.ImageIndex = 0;
 

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -20,6 +20,7 @@
  *    distribution.
  */
 
+using SAM.API;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -97,6 +98,8 @@ namespace SAM.Game
             {
                 base.Text += " | " + this._GameId.ToString(CultureInfo.InvariantCulture);
             }
+
+            this._SteamClient.SteamUserStats.RequestGlobalAchievementPercentages();
 
             this._UserStatsReceivedCallback = client.CreateAndRegisterCallback<API.Callbacks.UserStatsReceived>();
             this._UserStatsReceivedCallback.OnRun += this.OnUserStatsReceived;
@@ -358,8 +361,6 @@ namespace SAM.Game
                 this.EnableInput();
                 return;
             }
-
-            this._SteamClient.SteamUserStats.RequestGlobalAchievementPercentages();
 
             try
             {

--- a/SAM.Game/Stats/AchievementInfo.cs
+++ b/SAM.Game/Stats/AchievementInfo.cs
@@ -35,6 +35,7 @@ namespace SAM.Game.Stats
         public string IconLocked;
         public string Name;
         public string Description;
+        public float Progress;
         public ListViewItem Item;
 
         #region public int ImageIndex;


### PR DESCRIPTION
I think adding this extra info eliminates some extra steps for users. For these who'd like to use this tool in a 'smart' way to not open everything in a bulk, but with some understandable logic.
![GlobalProgress](https://github.com/user-attachments/assets/03adad05-9e59-4806-a39b-23db8dc91bc2)
