### PR TITLE
Add ability to filter via unlock time on achievements, using the string that appears

### DIFF
--- a/SAM.Game/Manager.Designer.cs
+++ b/SAM.Game/Manager.Designer.cs
@@ -323,7 +323,7 @@
             this._MatchingStringTextBox.Font = new System.Drawing.Font("Segoe UI", 9F);
             this._MatchingStringTextBox.Name = "_MatchingStringTextBox";
             this._MatchingStringTextBox.Size = new System.Drawing.Size(100, 25);
-            this._MatchingStringTextBox.ToolTipText = "Type at least 3 characters that must appear in the name or description";
+            this._MatchingStringTextBox.ToolTipText = "Type characters that appear in the name, description or unlock time of the achievement";
             this._MatchingStringTextBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.OnFilterUpdate);
             // 
             // _StatisticsTabPage

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -456,11 +456,17 @@ namespace SAM.Game
                 {
                     continue;
                 }
+                
+                DateTime? unlockTimeValue = isAchieved && unlockTime > 0 ? DateTimeOffset.FromUnixTimeSeconds(unlockTime).LocalDateTime : null;
 
                 if (textSearch != null)
                 {
-                    if (def.Name.IndexOf(textSearch, StringComparison.OrdinalIgnoreCase) < 0 &&
-                        def.Description.IndexOf(textSearch, StringComparison.OrdinalIgnoreCase) < 0)
+
+                    bool matchFound = def.Name.IndexOf(textSearch, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                      def.Description.IndexOf(textSearch, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                      unlockTimeValue.HasValue && unlockTimeValue.Value.ToString(CultureInfo.CurrentCulture).IndexOf(textSearch, StringComparison.OrdinalIgnoreCase) >= 0;
+
+                    if (!matchFound)
                     {
                         continue;
                     }
@@ -470,9 +476,7 @@ namespace SAM.Game
                 {
                     Id = def.Id,
                     IsAchieved = isAchieved,
-                    UnlockTime = isAchieved == true && unlockTime > 0
-                        ? DateTimeOffset.FromUnixTimeSeconds(unlockTime).LocalDateTime
-                        : null,
+                    UnlockTime = unlockTimeValue,
                     IconNormal = string.IsNullOrEmpty(def.IconNormal) ? null : def.IconNormal,
                     IconLocked = string.IsNullOrEmpty(def.IconLocked) ? def.IconNormal : def.IconLocked,
                     Permission = def.Permission,


### PR DESCRIPTION
Added the ability to filter via the unlock time, useful if you added a lot of specific achievements on a specific date and want to remove