### PR TITLE
Add SAM.CLI project for command-line achievement management

### DIFF
--- a/SAM.CLI/App.config
+++ b/SAM.CLI/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/SAM.CLI/GetAchievementsCommand.cs
+++ b/SAM.CLI/GetAchievementsCommand.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Newtonsoft.Json;
+using SAM.API;
+using APITypes = SAM.API.Types;
+
+namespace SAM.CLI
+{
+    class GetAchievementsCommand
+    {
+        public static object Execute(API.Client client, long appId)
+        {
+            try
+            {
+                // 1. Carregar o Schema (O Mapa das Conquistas)
+                string steamPath = API.Steam.GetInstallPath();
+                string schemaPath = System.IO.Path.Combine(
+                    steamPath,
+                    "appcache", "stats",
+                    $"UserGameStatsSchema_{appId}.bin"
+                );
+                
+                if (!System.IO.File.Exists(schemaPath))
+                {
+                    return new { 
+                        success = false, 
+                        error = $"Schema file not found at {schemaPath}. Run the game at least once.",
+                        appid = appId 
+                    };
+                }
+                
+                // Usando o KeyValue que copiamos para o projeto
+                var schemaKv = KeyValue.LoadAsBinary(schemaPath);
+                if (schemaKv == null)
+                {
+                    return new { success = false, error = "Failed to parse schema file", appid = appId };
+                }
+                
+                // 2. Extrair definições do Schema
+                var currentLanguage = client.SteamApps008.GetCurrentGameLanguage();
+                var achievementDefs = LoadAchievementDefinitions(schemaKv, appId, currentLanguage);
+                
+                // 3. Pedir Stats atuais para o Steam
+                var steamId = client.SteamUser.GetSteamId();
+                client.SteamUserStats.RequestUserStats(steamId);
+                
+                // Esperar um pouco para garantir que o Steam carregou (callback)
+                // O SAM original usa callbacks, aqui vamos fazer um loop simples de espera
+                bool statsReceived = false;
+                var callback = client.CreateAndRegisterCallback<API.Callbacks.UserStatsReceived>();
+                callback.OnRun += (param) => { statsReceived = true; };
+                
+                for (int i = 0; i < 20; i++) // Espera até 2 segundos
+                {
+                    client.RunCallbacks(false);
+                    if (statsReceived) break;
+                    Thread.Sleep(100);
+                }
+                
+                // 4. Cruzar os dados: Schema + Status Real
+                var achievements = new List<object>();
+                foreach (var def in achievementDefs)
+                {
+                    // Pergunta ao Steam o status desta conquista específica
+                    bool isAchieved;
+                    uint unlockTime;
+                    bool success = client.SteamUserStats.GetAchievementAndUnlockTime(def.Id, out isAchieved, out unlockTime);
+                    
+                    if (success)
+                    {
+                        achievements.Add(new {
+                            id = def.Id,
+                            name = def.Name,
+                            description = def.Description,
+                            unlocked = isAchieved,
+                            unlocktime = isAchieved && unlockTime > 0 ? (long)unlockTime : 0,
+                            icon = def.IconNormal,
+                            hidden = def.IsHidden
+                        });
+                    }
+                }
+                
+                return new {
+                    success = true,
+                    appid = appId,
+                    achievements = achievements,
+                    total = achievements.Count,
+                    unlocked = achievements.Count(a => ((dynamic)a).unlocked == true)
+                };
+            }
+            catch (Exception ex)
+            {
+                return new { success = false, error = ex.Message, stackTrace = ex.StackTrace };
+            }
+        }
+        
+        // Lógica extraída do SAM.Game/Manager.cs para ler a estrutura do arquivo binário
+        private static List<AchievementDefinition> LoadAchievementDefinitions(KeyValue schemaKv, long appId, string language)
+        {
+            var defs = new List<AchievementDefinition>();
+            
+            // Navega na estrutura: AppID -> stats
+            var stats = schemaKv[appId.ToString(CultureInfo.InvariantCulture)]["stats"];
+            if (!stats.Valid || stats.Children == null) return defs;
+            
+            foreach (var stat in stats.Children)
+            {
+                if (!stat.Valid) continue;
+                
+                // Verifica o tipo (Achievements = 3 ou 4)
+                var type = (APITypes.UserStatType)(stat["type_int"].Valid ? stat["type_int"].AsInteger(0) : stat["type"].AsInteger(0));
+                
+                if (type == APITypes.UserStatType.Achievements || type == APITypes.UserStatType.GroupAchievements)
+                {
+                    if (stat.Children == null) continue;
+                    
+                    // Procura pela seção "bits" onde ficam as conquistas
+                    foreach (var bits in stat.Children.Where(b => string.Compare(b.Name, "bits", StringComparison.InvariantCultureIgnoreCase) == 0))
+                    {
+                        if (!bits.Valid || bits.Children == null) continue;
+                        
+                        foreach (var bit in bits.Children)
+                        {
+                            string id = bit["name"].AsString("");
+                            if (string.IsNullOrEmpty(id)) continue;
+                            
+                            string name = GetLocalizedString(bit["display"]["name"], language, id);
+                            string desc = GetLocalizedString(bit["display"]["desc"], language, "");
+                            
+                            defs.Add(new AchievementDefinition {
+                                Id = id,
+                                Name = name,
+                                Description = desc,
+                                IconNormal = bit["display"]["icon"].AsString(""),
+                                IconLocked = bit["display"]["icon_gray"].AsString(""),
+                                IsHidden = bit["display"]["hidden"].AsBoolean(false)
+                            });
+                        }
+                    }
+                }
+            }
+            return defs;
+        }
+        
+        private static string GetLocalizedString(KeyValue kv, string language, string defaultValue)
+        {
+            var val = kv[language].AsString("");
+            if (!string.IsNullOrEmpty(val)) return val;
+            
+            val = kv["english"].AsString("");
+            if (!string.IsNullOrEmpty(val)) return val;
+            
+            val = kv.AsString("");
+            return !string.IsNullOrEmpty(val) ? val : defaultValue;
+        }
+    }
+    
+    class AchievementDefinition
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string IconNormal { get; set; }
+        public string IconLocked { get; set; }
+        public bool IsHidden { get; set; }
+    }
+}

--- a/SAM.CLI/KeyValue.cs
+++ b/SAM.CLI/KeyValue.cs
@@ -1,0 +1,323 @@
+/* Copyright (c) 2024 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SAM.CLI
+{
+    public class KeyValue
+    {
+        private static readonly KeyValue _Invalid = new KeyValue();
+        public string Name = "<root>";
+        public KeyValueType Type = KeyValueType.None;
+        public object Value;
+        public bool Valid;
+
+        public List<KeyValue> Children = null;
+
+        public KeyValue this[string key]
+        {
+            get
+            {
+                if (this.Children == null)
+                {
+                    return _Invalid;
+                }
+
+                var child = this.Children.SingleOrDefault(
+                    c => string.Compare(c.Name, key, StringComparison.InvariantCultureIgnoreCase) == 0);
+
+                if (child == null)
+                {
+                    return _Invalid;
+                }
+
+                return child;
+            }
+        }
+
+        public string AsString(string defaultValue)
+        {
+            if (this.Valid == false)
+            {
+                return defaultValue;
+            }
+
+            if (this.Value == null)
+            {
+                return defaultValue;
+            }
+
+            return this.Value.ToString();
+        }
+
+        public int AsInteger(int defaultValue)
+        {
+            if (this.Valid == false)
+            {
+                return defaultValue;
+            }
+
+            switch (this.Type)
+            {
+                case KeyValueType.String:
+                case KeyValueType.WideString:
+                {
+                    return int.TryParse((string)this.Value, out int value) == false
+                        ? defaultValue
+                        : value;
+                }
+
+                case KeyValueType.Int32:
+                {
+                    return (int)this.Value;
+                }
+
+                case KeyValueType.Float32:
+                {
+                    return (int)((float)this.Value);
+                }
+
+                case KeyValueType.UInt64:
+                {
+                    return (int)((ulong)this.Value & 0xFFFFFFFF);
+                }
+            }
+
+            return defaultValue;
+        }
+
+        public float AsFloat(float defaultValue)
+        {
+            if (this.Valid == false)
+            {
+                return defaultValue;
+            }
+
+            switch (this.Type)
+            {
+                case KeyValueType.String:
+                case KeyValueType.WideString:
+                {
+                    return float.TryParse((string)this.Value, out float value) == false
+                        ? defaultValue
+                        : value;
+                }
+
+                case KeyValueType.Int32:
+                {
+                    return (int)this.Value;
+                }
+
+                case KeyValueType.Float32:
+                {
+                    return (float)this.Value;
+                }
+
+                case KeyValueType.UInt64:
+                {
+                    return (ulong)this.Value & 0xFFFFFFFF;
+                }
+            }
+
+            return defaultValue;
+        }
+
+        public bool AsBoolean(bool defaultValue)
+        {
+            if (this.Valid == false)
+            {
+                return defaultValue;
+            }
+
+            switch (this.Type)
+            {
+                case KeyValueType.String:
+                case KeyValueType.WideString:
+                {
+                    return int.TryParse((string)this.Value, out int value) == false
+                        ? defaultValue
+                        : value != 0;
+                }
+
+                case KeyValueType.Int32:
+                {
+                    return ((int)this.Value) != 0;
+                }
+
+                case KeyValueType.Float32:
+                {
+                    return ((int)((float)this.Value)) != 0;
+                }
+
+                case KeyValueType.UInt64:
+                {
+                    return ((ulong)this.Value) != 0;
+                }
+            }
+
+            return defaultValue;
+        }
+
+        public override string ToString()
+        {
+            if (this.Valid == false)
+            {
+                return "<invalid>";
+            }
+
+            if (this.Type == KeyValueType.None)
+            {
+                return this.Name;
+            }
+
+            return $"{this.Name} = {this.Value}";
+        }
+
+        public static KeyValue LoadAsBinary(string path)
+        {
+            if (File.Exists(path) == false)
+            {
+                return null;
+            }
+
+            try
+            {
+                using (var input = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    KeyValue kv = new KeyValue();
+                    if (kv.ReadAsBinary(input) == false)
+                    {
+                        return null;
+                    }
+                    return kv;
+                }
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        public bool ReadAsBinary(Stream input)
+        {
+            this.Children = new List<KeyValue>();
+            try
+            {
+                while (true)
+                {
+                    var type = (KeyValueType)input.ReadValueU8();
+
+                    if (type == KeyValueType.End)
+                    {
+                        break;
+                    }
+
+                    KeyValue current = new KeyValue
+                    {
+                        Type = type,
+                        Name = input.ReadStringUnicode(),
+                    };
+
+                    switch (type)
+                    {
+                        case KeyValueType.None:
+                        {
+                            current.ReadAsBinary(input);
+                            break;
+                        }
+
+                        case KeyValueType.String:
+                        {
+                            current.Valid = true;
+                            current.Value = input.ReadStringUnicode();
+                            break;
+                        }
+
+                        case KeyValueType.WideString:
+                        {
+                            throw new FormatException("wstring is unsupported");
+                        }
+
+                        case KeyValueType.Int32:
+                        {
+                            current.Valid = true;
+                            current.Value = input.ReadValueS32();
+                            break;
+                        }
+
+                        case KeyValueType.UInt64:
+                        {
+                            current.Valid = true;
+                            current.Value = input.ReadValueU64();
+                            break;
+                        }
+
+                        case KeyValueType.Float32:
+                        {
+                            current.Valid = true;
+                            current.Value = input.ReadValueF32();
+                            break;
+                        }
+
+                        case KeyValueType.Color:
+                        {
+                            current.Valid = true;
+                            current.Value = input.ReadValueU32();
+                            break;
+                        }
+
+                        case KeyValueType.Pointer:
+                        {
+                            current.Valid = true;
+                            current.Value = input.ReadValueU32();
+                            break;
+                        }
+
+                        default:
+                        {
+                            throw new FormatException();
+                        }
+                    }
+
+                    if (input.Position >= input.Length)
+                    {
+                        throw new FormatException();
+                    }
+
+                    this.Children.Add(current);
+                }
+
+                this.Valid = true;
+                return input.Position == input.Length;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}
+

--- a/SAM.CLI/KeyValueType.cs
+++ b/SAM.CLI/KeyValueType.cs
@@ -1,0 +1,38 @@
+/* Copyright (c) 2024 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+namespace SAM.CLI
+{
+    public enum KeyValueType : byte
+    {
+        None = 0,
+        String = 1,
+        Int32 = 2,
+        Float32 = 3,
+        Pointer = 4,
+        WideString = 5,
+        Color = 6,
+        UInt64 = 7,
+        End = 8,
+    }
+}
+

--- a/SAM.CLI/LockCommand.cs
+++ b/SAM.CLI/LockCommand.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading;
+using Newtonsoft.Json;
+using SAM.API;
+
+namespace SAM.CLI
+{
+    class LockCommand
+    {
+        public static object Execute(API.Client client, long appId, string achievementId)
+        {
+            if (string.IsNullOrEmpty(achievementId))
+            {
+                return new
+                {
+                    success = false,
+                    error = "Achievement ID is required",
+                    usage = "SAM.CLI.exe lock <appid> <achievement_id>"
+                };
+            }
+
+            try
+            {
+                // Request stats first
+                var steamId = client.SteamUser.GetSteamId();
+                var callHandle = client.SteamUserStats.RequestUserStats(steamId);
+
+                bool statsReceived = false;
+                API.Callbacks.UserStatsReceived callback = null;
+
+                callback = client.CreateAndRegisterCallback<API.Callbacks.UserStatsReceived>();
+                callback.OnRun += (param) => {
+                    if (param.Result == 1)
+                    {
+                        statsReceived = true;
+                    }
+                };
+
+                int attempts = 0;
+                while (!statsReceived && attempts < 50)
+                {
+                    client.RunCallbacks(false);
+                    Thread.Sleep(100);
+                    attempts++;
+                }
+
+                if (!statsReceived)
+                {
+                    return new
+                    {
+                        success = false,
+                        error = "Timeout waiting for stats to load"
+                    };
+                }
+
+                // Set achievement to locked (false)
+                if (!client.SteamUserStats.SetAchievement(achievementId, false))
+                {
+                    return new
+                    {
+                        success = false,
+                        error = $"Failed to lock achievement {achievementId}"
+                    };
+                }
+
+                // Store stats
+                if (!client.SteamUserStats.StoreStats())
+                {
+                    return new
+                    {
+                        success = false,
+                        error = "Failed to store stats"
+                    };
+                }
+
+                return new
+                {
+                    success = true,
+                    appid = appId,
+                    achievement_id = achievementId,
+                    message = $"Achievement {achievementId} locked successfully"
+                };
+            }
+            catch (Exception ex)
+            {
+                return new
+                {
+                    success = false,
+                    error = ex.Message,
+                    stackTrace = ex.StackTrace
+                };
+            }
+        }
+    }
+}

--- a/SAM.CLI/Program.cs
+++ b/SAM.CLI/Program.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using SAM.API;
+using APITypes = SAM.API.Types;
+using JsonFormatting = Newtonsoft.Json.Formatting; // Alias para evitar conflito
+
+namespace SAM.CLI
+{
+    // Classe para resultado padronizado
+    public class CommandResult
+    {
+        public bool success { get; set; }
+        public string error { get; set; }
+        public object data { get; set; }
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.Error.WriteLine("Usage: SAM.CLI.exe <command> <appid> [args...]");
+                Console.Error.WriteLine("Commands:");
+                Console.Error.WriteLine("  get-achievements <appid>           - List all achievements");
+                Console.Error.WriteLine("  unlock <appid> <achievement_id>   - Unlock an achievement");
+                Console.Error.WriteLine("  lock <appid> <achievement_id>     - Lock an achievement");
+                return 1;
+            }
+
+            string command = args[0].ToLower();
+            if (!long.TryParse(args[1], out long appId))
+            {
+                var errorResult = new { success = false, error = $"Invalid appid: {args[1]}" };
+                Console.Error.WriteLine(JsonConvert.SerializeObject(errorResult, JsonFormatting.Indented));
+                return 1;
+            }
+
+            try
+            {
+                using (var client = new API.Client())
+                {
+                    client.Initialize(appId);
+
+                    object result = null;
+
+                    // Usar if/else ao invés de switch expression
+                    if (command == "get-achievements")
+                    {
+                        result = GetAchievementsCommand.Execute(client, appId);
+                    }
+                    else if (command == "unlock")
+                    {
+                        string achievementId = args.Length > 2 ? args[2] : null;
+                        result = UnlockCommand.Execute(client, appId, achievementId);
+                    }
+                    else if (command == "lock")
+                    {
+                        string achievementId = args.Length > 2 ? args[2] : null;
+                        result = LockCommand.Execute(client, appId, achievementId);
+                    }
+                    else
+                    {
+                        result = new { success = false, error = $"Unknown command: {command}" };
+                    }
+
+                    string json = JsonConvert.SerializeObject(result, JsonFormatting.Indented);
+                    Console.WriteLine(json);
+
+                    // Verificar success usando reflection ou try-cast
+                    try
+                    {
+                        var resultType = result.GetType();
+                        var successProp = resultType.GetProperty("success");
+                        if (successProp != null)
+                        {
+                            var successValue = successProp.GetValue(result);
+                            if (successValue is bool boolVal && boolVal == false)
+                            {
+                                return 1;
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // Se não conseguir verificar, assume sucesso
+                    }
+
+                    return 0;
+                }
+            }
+            catch (API.ClientInitializeException ex)
+            {
+                var error = new
+                {
+                    success = false,
+                    error = "Steam is not running or failed to initialize",
+                    details = ex.Message
+                };
+                Console.Error.WriteLine(JsonConvert.SerializeObject(error, JsonFormatting.Indented));
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                var error = new
+                {
+                    success = false,
+                    error = ex.Message,
+                    stackTrace = ex.StackTrace
+                };
+                Console.Error.WriteLine(JsonConvert.SerializeObject(error, JsonFormatting.Indented));
+                return 1;
+            }
+        }
+    }
+}

--- a/SAM.CLI/Properties/AssemblyInfo.cs
+++ b/SAM.CLI/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// As informações gerais sobre um assembly são controladas por
+// conjunto de atributos. Altere estes valores de atributo para modificar as informações
+// associadas a um assembly.
+[assembly: AssemblyTitle("SAM.CLI")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SAM.CLI")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Definir ComVisible como false torna os tipos neste assembly invisíveis
+// para componentes COM. Caso precise acessar um tipo neste assembly de
+// COM, defina o atributo ComVisible como true nesse tipo.
+[assembly: ComVisible(false)]
+
+// O GUID a seguir será destinado à ID de typelib se este projeto for exposto para COM
+[assembly: Guid("c766dc90-3cf6-45e2-9eb8-83c71ffbc6f7")]
+
+// As informações da versão de um assembly consistem nos quatro valores a seguir:
+//
+//      Versão Principal
+//      Versão Secundária 
+//      Número da Versão
+//      Revisão
+//
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SAM.CLI/SAM.CLI.csproj
+++ b/SAM.CLI/SAM.CLI.csproj
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SAM.CLI</RootNamespace>
+    <AssemblyName>SAM.CLI</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="GetAchievementsCommand.cs" />
+    <Compile Include="KeyValue.cs" />
+    <Compile Include="KeyValueType.cs" />
+    <Compile Include="StreamHelpers.cs" />
+    <Compile Include="LockCommand.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnlockCommand.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SAM.API\SAM.API.csproj">
+      <Project>{df9102d5-048a-4d21-8ce3-3544cbdf0ed1}</Project>
+      <Name>SAM.API</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SAM.Game\SAM.Game.csproj">
+      <Project>{7640de31-e54e-45f9-9cf0-8df3a3ea30fc}</Project>
+      <Name>SAM.Game</Name>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/SAM.CLI/StreamHelpers.cs
+++ b/SAM.CLI/StreamHelpers.cs
@@ -1,0 +1,116 @@
+/* Copyright (c) 2024 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace SAM.CLI
+{
+    public static class StreamHelpers
+    {
+        public static byte ReadValueU8(this Stream stream)
+        {
+            return (byte)stream.ReadByte();
+        }
+
+        public static int ReadValueS32(this Stream stream)
+        {
+            var data = new byte[4];
+            int read = stream.Read(data, 0, 4);
+            Debug.Assert(read == 4);
+            return BitConverter.ToInt32(data, 0);
+        }
+
+        public static uint ReadValueU32(this Stream stream)
+        {
+            var data = new byte[4];
+            int read = stream.Read(data, 0, 4);
+            Debug.Assert(read == 4);
+            return BitConverter.ToUInt32(data, 0);
+        }
+
+        public static ulong ReadValueU64(this Stream stream)
+        {
+            var data = new byte[8];
+            int read = stream.Read(data, 0, 8);
+            Debug.Assert(read == 8);
+            return BitConverter.ToUInt64(data, 0);
+        }
+
+        public static float ReadValueF32(this Stream stream)
+        {
+            var data = new byte[4];
+            int read = stream.Read(data, 0, 4);
+            Debug.Assert(read == 4);
+            return BitConverter.ToSingle(data, 0);
+        }
+
+        internal static string ReadStringInternalDynamic(this Stream stream, Encoding encoding, char end)
+        {
+            int characterSize = encoding.GetByteCount("e");
+            Debug.Assert(characterSize == 1 || characterSize == 2 || characterSize == 4);
+            string characterEnd = end.ToString(CultureInfo.InvariantCulture);
+
+            int i = 0;
+            var data = new byte[128 * characterSize];
+
+            while (true)
+            {
+                if (i + characterSize > data.Length)
+                {
+                    Array.Resize(ref data, data.Length + (128 * characterSize));
+                }
+
+                int read = stream.Read(data, i, characterSize);
+                Debug.Assert(read == characterSize);
+
+                if (encoding.GetString(data, i, characterSize) == characterEnd)
+                {
+                    break;
+                }
+
+                i += characterSize;
+            }
+
+            if (i == 0)
+            {
+                return "";
+            }
+
+            return encoding.GetString(data, 0, i);
+        }
+
+        public static string ReadStringAscii(this Stream stream)
+        {
+            return stream.ReadStringInternalDynamic(Encoding.ASCII, '\0');
+        }
+
+        public static string ReadStringUnicode(this Stream stream)
+        {
+            return stream.ReadStringInternalDynamic(Encoding.UTF8, '\0');
+        }
+    }
+}
+

--- a/SAM.CLI/UnlockCommand.cs
+++ b/SAM.CLI/UnlockCommand.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Threading;
+using Newtonsoft.Json;
+using SAM.API;
+
+namespace SAM.CLI
+{
+    class UnlockCommand
+    {
+        public static object Execute(API.Client client, long appId, string achievementId)
+        {
+            if (string.IsNullOrEmpty(achievementId))
+            {
+                return new
+                {
+                    success = false,
+                    error = "Achievement ID is required",
+                    usage = "SAM.CLI.exe unlock <appid> <achievement_id>"
+                };
+            }
+
+            try
+            {
+                // Request stats first to ensure they're loaded
+                var steamId = client.SteamUser.GetSteamId();
+                var callHandle = client.SteamUserStats.RequestUserStats(steamId);
+
+                // Wait for stats to load
+                bool statsReceived = false;
+                API.Callbacks.UserStatsReceived callback = null;
+
+                callback = client.CreateAndRegisterCallback<API.Callbacks.UserStatsReceived>();
+                callback.OnRun += (param) => {
+                    if (param.Result == 1)
+                    {
+                        statsReceived = true;
+                    }
+                };
+
+                int attempts = 0;
+                while (!statsReceived && attempts < 50)
+                {
+                    client.RunCallbacks(false);
+                    Thread.Sleep(100);
+                    attempts++;
+                }
+
+                if (!statsReceived)
+                {
+                    return new
+                    {
+                        success = false,
+                        error = "Timeout waiting for stats to load"
+                    };
+                }
+
+                // Set achievement to unlocked
+                if (!client.SteamUserStats.SetAchievement(achievementId, true))
+                {
+                    return new
+                    {
+                        success = false,
+                        error = $"Failed to set achievement {achievementId}"
+                    };
+                }
+
+                // Store stats to file
+                if (!client.SteamUserStats.StoreStats())
+                {
+                    return new
+                    {
+                        success = false,
+                        error = "Failed to store stats"
+                    };
+                }
+
+                return new
+                {
+                    success = true,
+                    appid = appId,
+                    achievement_id = achievementId,
+                    message = $"Achievement {achievementId} unlocked successfully"
+                };
+            }
+            catch (Exception ex)
+            {
+                return new
+                {
+                    success = false,
+                    error = ex.Message,
+                    stackTrace = ex.StackTrace
+                };
+            }
+        }
+    }
+}

--- a/SAM.CLI/packages.config
+++ b/SAM.CLI/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
+</packages>

--- a/SAM.sln
+++ b/SAM.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36616.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.Picker", "SAM.Picker\SAM.Picker.csproj", "{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}"
 EndProject
@@ -9,24 +9,52 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.API", "SAM.API\SAM.API.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAM.Game", "SAM.Game\SAM.Game.csproj", "{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAM.CLI", "SAM.CLI\SAM.CLI.csproj", "{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|Any CPU.Build.0 = Debug|x86
 		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|x86.ActiveCfg = Debug|x86
 		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Debug|x86.Build.0 = Debug|x86
+		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|Any CPU.ActiveCfg = Release|x86
+		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|Any CPU.Build.0 = Release|x86
 		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|x86.ActiveCfg = Release|x86
 		{E89E57BB-0F09-47F3-98A0-2026E2E65FBA}.Release|x86.Build.0 = Release|x86
+		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|Any CPU.Build.0 = Debug|x86
 		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|x86.ActiveCfg = Debug|x86
 		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Debug|x86.Build.0 = Debug|x86
+		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|Any CPU.ActiveCfg = Release|x86
+		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|Any CPU.Build.0 = Release|x86
 		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|x86.ActiveCfg = Release|x86
 		{DF9102D5-048A-4D21-8CE3-3544CBDF0ED1}.Release|x86.Build.0 = Release|x86
+		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|Any CPU.Build.0 = Debug|x86
 		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|x86.ActiveCfg = Debug|x86
 		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Debug|x86.Build.0 = Debug|x86
+		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|Any CPU.ActiveCfg = Release|x86
+		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|Any CPU.Build.0 = Release|x86
 		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x86.ActiveCfg = Release|x86
 		{7640DE31-E54E-45F9-9CF0-8DF3A3EA30FC}.Release|x86.Build.0 = Release|x86
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Debug|x86.Build.0 = Debug|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Release|x86.ActiveCfg = Release|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Release|x86.Build.0 = Release|Any CPU
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Debug|x86.ActiveCfg = Debug|x86
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Debug|x86.Build.0 = Debug|x86
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Release|x86.ActiveCfg = Release|x86
+		{C766DC90-3CF6-45E2-9EB8-83C71FFBC6F7}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Introduces a new SAM.CLI project that provides a command-line interface for managing Steam achievements. Includes commands to list, unlock, and lock achievements for a given appid, with JSON output. Adds supporting files for achievement schema parsing, binary KeyValue reading, and project configuration. Updates the solution file to include the new project.