### PR TITLE
feat: add date-based achievement filtering and lock visible button

### DIFF
--- a/SAM.Game/Manager.Designer.cs
+++ b/SAM.Game/Manager.Designer.cs
@@ -55,6 +55,18 @@
             this._DisplayLabel = new System.Windows.Forms.ToolStripLabel();
             this._DisplayLockedOnlyButton = new System.Windows.Forms.ToolStripButton();
             this._DisplayUnlockedOnlyButton = new System.Windows.Forms.ToolStripButton();
+            this._LockVisibleButton = new System.Windows.Forms.ToolStripButton();
+            this._DateFilterLabel = new System.Windows.Forms.ToolStripLabel();
+            var innerDatePicker = new System.Windows.Forms.DateTimePicker()
+            {
+                Format = System.Windows.Forms.DateTimePickerFormat.Short,
+                Size = new System.Drawing.Size(100, 22),
+                Enabled = false,
+                Name = "_InnerDatePicker"
+            };
+            this._DateFilterPicker = new System.Windows.Forms.ToolStripControlHost(innerDatePicker);
+            this._DateFilterCheckBox = new System.Windows.Forms.ToolStripButton();
+            _ToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this._MatchingStringLabel = new System.Windows.Forms.ToolStripLabel();
             this._MatchingStringTextBox = new System.Windows.Forms.ToolStripTextBox();
             this._StatisticsTabPage = new System.Windows.Forms.TabPage();
@@ -237,6 +249,7 @@
             // 
             this._AchievementsToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this._LockAllButton,
+            this._LockVisibleButton,
             this._InvertAllButton,
             this._UnlockAllButton,
             _ToolStripSeparator1,
@@ -244,6 +257,9 @@
             this._DisplayLockedOnlyButton,
             this._DisplayUnlockedOnlyButton,
             _ToolStripSeparator2,
+            this._DateFilterLabel,
+            this._DateFilterCheckBox,
+            this._DateFilterPicker,
             this._MatchingStringLabel,
             this._MatchingStringTextBox});
             this._AchievementsToolStrip.Location = new System.Drawing.Point(3, 3);
@@ -310,9 +326,44 @@
             this._DisplayUnlockedOnlyButton.Size = new System.Drawing.Size(60, 22);
             this._DisplayUnlockedOnlyButton.Text = "unlocked";
             this._DisplayUnlockedOnlyButton.Click += new System.EventHandler(this.OnDisplayUncheckedOnly);
-            // 
+            //
+            // _LockVisibleButton
+            //
+            this._LockVisibleButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this._LockVisibleButton.Image = global::SAM.Game.Resources.Lock;
+            this._LockVisibleButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this._LockVisibleButton.Name = "_LockVisibleButton";
+            this._LockVisibleButton.Size = new System.Drawing.Size(23, 22);
+            this._LockVisibleButton.Text = "Lock Visible";
+            this._LockVisibleButton.ToolTipText = "Lock all currently visible achievements.";
+            this._LockVisibleButton.Click += new System.EventHandler(this.OnLockVisible);
+            //
+            // _DateFilterLabel
+            //
+            this._DateFilterLabel.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this._DateFilterLabel.Name = "_DateFilterLabel";
+            this._DateFilterLabel.Size = new System.Drawing.Size(33, 22);
+            this._DateFilterLabel.Text = "Date";
+            //
+            // _DateFilterCheckBox
+            //
+            this._DateFilterCheckBox.CheckOnClick = true;
+            this._DateFilterCheckBox.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this._DateFilterCheckBox.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this._DateFilterCheckBox.Name = "_DateFilterCheckBox";
+            this._DateFilterCheckBox.Size = new System.Drawing.Size(60, 22);
+            this._DateFilterCheckBox.Text = "filter on";
+            this._DateFilterCheckBox.ToolTipText = "Toggle date filtering for achievements.";
+            this._DateFilterCheckBox.Click += new System.EventHandler(this.OnDateFilterToggle);
+            //
+            // _DateFilterPicker
+            //
+            innerDatePicker.ValueChanged += new System.EventHandler(this.OnDateFilterChanged);
+            this._DateFilterPicker.Name = "_DateFilterPicker";
+            this._DateFilterPicker.Size = new System.Drawing.Size(110, 25);
+            //
             // _MatchingStringLabel
-            // 
+            //
             this._MatchingStringLabel.Font = new System.Drawing.Font("Segoe UI", 9F);
             this._MatchingStringLabel.Name = "_MatchingStringLabel";
             this._MatchingStringLabel.Size = new System.Drawing.Size(33, 22);
@@ -425,6 +476,10 @@
         private System.Windows.Forms.ToolStripLabel _MatchingStringLabel;
         private System.Windows.Forms.ToolStripTextBox _MatchingStringTextBox;
         private System.Windows.Forms.ColumnHeader _AchievementUnlockTimeColumnHeader;
+        private System.Windows.Forms.ToolStripButton _LockVisibleButton;
+        private System.Windows.Forms.ToolStripLabel _DateFilterLabel;
+        private System.Windows.Forms.ToolStripControlHost _DateFilterPicker;
+        private System.Windows.Forms.ToolStripButton _DateFilterCheckBox;
         private System.Windows.Forms.CheckBox _EnableStatsEditingCheckBox;
     }
 }

--- a/SAM.Game/Manager.cs
+++ b/SAM.Game/Manager.cs
@@ -487,6 +487,20 @@ namespace SAM.Game
                     }
                 }
 
+                // Date filtering
+                if (this._DateFilterCheckBox.Checked)
+                {
+                    var innerPicker = (System.Windows.Forms.DateTimePicker)this._DateFilterPicker.Control;
+                    var filterDate = innerPicker.Value.Date;
+
+                    // Only show achievements that were unlocked on the selected date
+                    if (isAchieved == false || unlockTime <= 0 ||
+                        DateTimeOffset.FromUnixTimeSeconds(unlockTime).LocalDateTime.Date != filterDate)
+                    {
+                        continue;
+                    }
+                }
+
                 Stats.AchievementInfo info = new()
                 {
                     Id = def.Id,
@@ -908,6 +922,29 @@ namespace SAM.Game
             }
 
             this.GetAchievements();
+        }
+
+        private void OnLockVisible(object sender, EventArgs e)
+        {
+            foreach (ListViewItem item in this._AchievementListView.Items)
+            {
+                item.Checked = false;
+            }
+        }
+
+        private void OnDateFilterToggle(object sender, EventArgs e)
+        {
+            var innerPicker = (System.Windows.Forms.DateTimePicker)this._DateFilterPicker.Control;
+            innerPicker.Enabled = this._DateFilterCheckBox.Checked;
+            this.GetAchievements();
+        }
+
+        private void OnDateFilterChanged(object sender, EventArgs e)
+        {
+            if (this._DateFilterCheckBox.Checked)
+            {
+                this.GetAchievements();
+            }
         }
 
         private void OnFilterUpdate(object sender, KeyEventArgs e)

--- a/SAM.Game/SAM.Game.csproj
+++ b/SAM.Game/SAM.Game.csproj
@@ -25,6 +25,7 @@
     <LangVersion>9.0</LangVersion>
     <Platforms>x86</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>..\bin\</OutputPath>
@@ -55,5 +56,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SAM.API\SAM.API.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/SAM.Picker/SAM.Picker.csproj
+++ b/SAM.Picker/SAM.Picker.csproj
@@ -25,6 +25,7 @@
     <LangVersion>9.0</LangVersion>
     <Platforms>x86</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>..\bin\</OutputPath>
@@ -55,5 +56,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SAM.API\SAM.API.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Add date-based achievement filtering and a "Lock Visible" button to enable bulk un-achieving of all achievements unlocked on a specific date.

## Context
Currently, SAM has no way to filter achievements by their unlock date. Users who want to un-achieve all achievements unlocked on a specific date must manually scroll through the list, identify them by the "Unlock Time" column, and uncheck each one individually. This is tedious and error-prone, especially for games with many achievements.

Closes #603

## Changes

### New UI Controls (Achievement Toolbar)
- **"Lock Visible"** button (lock icon) — unchecks all currently visible achievements in one click
- **"Date"** label + **"filter on"** toggle + **date picker** — enables date-based filtering of achievements

### Logic Changes
- Added date filtering in `GetAchievements()` that compares each achievement's `unlockTime` (Unix timestamp) against the selected date (converted to local date)
- Date filter works in combination with existing text filter and locked/unlocked display filters
- `OnLockVisible` handler unchecks all visible items
- `OnDateFilterToggle` enables/disables the date picker and refreshes the list
- `OnDateFilterChanged` refreshes the list when the date changes (only when filter is active)

### Build Fixes
- Added `GenerateResourceUsePreserializedResources` property and `System.Resources.Extensions` NuGet package to both `SAM.Game` and `SAM.Picker` csproj files to fix building with .NET 8 SDK

## Use Cases
1. **Undo accidental batch unlock**: Filter by the date achievements were incorrectly unlocked, then lock all visible and commit
2. **Clean up specific day's progress**: Select a date, see only that day's achievements, lock them all
3. **Combined with existing filters**: Use date filter + text filter + locked/unlocked filter together for precise control

## Testing
1. Build the solution: `dotnet build SAM.sln -c Debug`
2. Run SAM and select a game with unlocked achievements
3. Click "filter on" next to "Date" in the toolbar
4. Select a date — only achievements unlocked on that date should appear
5. Click the "Lock Visible" button — all visible achievements should be unchecked
6. Click "Commit Changes" — changes should be stored

## Files Changed
- `SAM.Game/Manager.Designer.cs` — New UI controls in toolbar
- `SAM.Game/Manager.cs` — Date filtering logic + event handlers
- `SAM.Game/SAM.Game.csproj` — Build fix for .NET 8 SDK
- `SAM.Picker/SAM.Picker.csproj` — Build fix for .NET 8 SDK
