### PR TITLE
Add a show only favourites filter

### DIFF
--- a/SAM.Picker/GamePicker.Designer.cs
+++ b/SAM.Picker/GamePicker.Designer.cs
@@ -31,6 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.Windows.Forms.ToolStripSeparator _ToolStripSeparator1;
             System.Windows.Forms.ToolStripSeparator _ToolStripSeparator2;
+            System.Windows.Forms.ToolStripSeparator _ToolStripSeparator3;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GamePicker));
             this._LogoImageList = new System.Windows.Forms.ImageList(this.components);
             this._CallbackTimer = new System.Windows.Forms.Timer(this.components);
@@ -45,6 +46,7 @@
             this._FilterDemosMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._FilterModsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._FilterJunkMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this._FilterFavoritesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._GameListView = new SAM.Picker.MyListView();
             this._PickerStatusStrip = new System.Windows.Forms.StatusStrip();
             this._PickerStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
@@ -53,6 +55,7 @@
             this._ListWorker = new System.ComponentModel.BackgroundWorker();
             _ToolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             _ToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            _ToolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this._PickerToolStrip.SuspendLayout();
             this._PickerStatusStrip.SuspendLayout();
             this.SuspendLayout();
@@ -66,6 +69,11 @@
             //
             _ToolStripSeparator2.Name = "_ToolStripSeparator2";
             _ToolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            //
+            // _ToolStripSeparator3
+            //
+            _ToolStripSeparator3.Name = "_ToolStripSeparator3";
+            _ToolStripSeparator3.Size = new System.Drawing.Size(177, 6);
             //
             // _LogoImageList
             //
@@ -139,7 +147,9 @@
             this._FilterGamesMenuItem,
             this._FilterDemosMenuItem,
             this._FilterModsMenuItem,
-            this._FilterJunkMenuItem});
+            this._FilterJunkMenuItem,
+            _ToolStripSeparator3,
+            this._FilterFavoritesMenuItem});
             this._FilterDropDownButton.Image = global::SAM.Picker.Resources.Filter;
             this._FilterDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this._FilterDropDownButton.Name = "_FilterDropDownButton";
@@ -179,6 +189,14 @@
             this._FilterJunkMenuItem.Size = new System.Drawing.Size(180, 22);
             this._FilterJunkMenuItem.Text = "Show &junk";
             this._FilterJunkMenuItem.CheckedChanged += new System.EventHandler(this.OnFilterUpdate);
+            //
+            // _FilterFavoritesMenuItem
+            //
+            this._FilterFavoritesMenuItem.CheckOnClick = true;
+            this._FilterFavoritesMenuItem.Name = "_FilterFavoritesMenuItem";
+            this._FilterFavoritesMenuItem.Size = new System.Drawing.Size(180, 22);
+            this._FilterFavoritesMenuItem.Text = "Show only &favourites";
+            this._FilterFavoritesMenuItem.CheckedChanged += new System.EventHandler(this.OnFilterUpdate);
             //
             // _GameListView
             //
@@ -272,6 +290,7 @@
         private System.Windows.Forms.ToolStripMenuItem _FilterJunkMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _FilterDemosMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _FilterModsMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem _FilterFavoritesMenuItem;
         private System.Windows.Forms.StatusStrip _PickerStatusStrip;
         private System.Windows.Forms.ToolStripStatusLabel _DownloadStatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel _PickerStatusLabel;

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -43,6 +43,7 @@ namespace SAM.Picker
 
         private readonly Dictionary<uint, GameInfo> _Games;
         private readonly List<GameInfo> _FilteredGames;
+        private HashSet<uint> _FavoriteGameIds;
 
         private readonly object _LogoLock;
         private readonly HashSet<string> _LogosAttempting;
@@ -55,6 +56,7 @@ namespace SAM.Picker
         {
             this._Games = new();
             this._FilteredGames = new();
+            this._FavoriteGameIds = new();
             this._LogoLock = new();
             this._LogosAttempting = new();
             this._LogosAttempted = new();
@@ -153,6 +155,12 @@ namespace SAM.Picker
             var wantDemos = this._FilterDemosMenuItem.Checked == true;
             var wantMods = this._FilterModsMenuItem.Checked == true;
             var wantJunk = this._FilterJunkMenuItem.Checked == true;
+            var wantFavoritesOnly = this._FilterFavoritesMenuItem.Checked == true;
+
+            foreach (var info in this._Games.Values)
+            {
+                info.Item = null;
+            }
 
             this._FilteredGames.Clear();
             foreach (var info in this._Games.Values.OrderBy(gi => gi.Name))
@@ -172,6 +180,12 @@ namespace SAM.Picker
                     _ => true,
                 };
                 if (wanted == false)
+                {
+                    continue;
+                }
+
+                if (wantFavoritesOnly == true &&
+                    this._FavoriteGameIds.Contains(info.Id) == false)
                 {
                     continue;
                 }
@@ -315,10 +329,14 @@ namespace SAM.Picker
 
                     if (info.Item == null)
                     {
+                        this._LogosAttempting.Remove(info.ImageUrl);
                         continue;
                     }
 
-                    if (this._FilteredGames.Contains(info) == false ||
+                    int itemIndex = info.Item.Index;
+                    if (itemIndex < 0 ||
+                        itemIndex >= this._FilteredGames.Count ||
+                        ReferenceEquals(this._FilteredGames[itemIndex], info) == false ||
                         info.Item.Bounds.IntersectsWith(this._GameListView.ClientRectangle) == false)
                     {
                         this._LogosAttempting.Remove(info.ImageUrl);
@@ -418,6 +436,7 @@ namespace SAM.Picker
 
         private void AddGames()
         {
+            this._FavoriteGameIds = SteamLibraryFavorites.Load();
             this._Games.Clear();
             this._RefreshGamesButton.Enabled = false;
             this._ListWorker.RunWorkerAsync();
@@ -502,12 +521,19 @@ namespace SAM.Picker
             this._Games.Clear();
             this.AddGame(id, "normal");
             this._FilterGamesMenuItem.Checked = true;
+            this._FilterFavoritesMenuItem.Checked = false;
             this.RefreshGames();
             this.DownloadNextLogo();
         }
 
         private void OnFilterUpdate(object sender, EventArgs e)
         {
+            if (ReferenceEquals(sender, this._FilterFavoritesMenuItem) == true &&
+                this._FilterFavoritesMenuItem.Checked == true)
+            {
+                this._FavoriteGameIds = SteamLibraryFavorites.Load();
+            }
+
             this.RefreshGames();
 
             // Compatibility with _GameListView SearchForVirtualItemEventHandler (otherwise _SearchGameTextBox loose focus on KeyUp)

--- a/SAM.Picker/SteamLibraryFavorites.cs
+++ b/SAM.Picker/SteamLibraryFavorites.cs
@@ -1,0 +1,636 @@
+﻿/* Copyright (c) 2024 Rick (rick 'at' gibbed 'dot' us)
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace SAM.Picker
+{
+    internal static class SteamLibraryFavorites
+    {
+        private const string FavoritesKey = "user-collections.favorite";
+
+        public static HashSet<uint> Load()
+        {
+            HashSet<uint> favorites = new();
+
+            try
+            {
+                string steamPath = API.Steam.GetInstallPath();
+                if (string.IsNullOrEmpty(steamPath) == true)
+                {
+                    return favorites;
+                }
+
+                foreach (string accountId in GetAccountIds(steamPath))
+                {
+                    string path = Path.Combine(
+                        steamPath,
+                        "userdata",
+                        accountId,
+                        "config",
+                        "cloudstorage",
+                        "cloud-storage-namespace-1.json");
+
+                    var loaded = LoadFromCloudStorage(path);
+                    if (loaded.Found == true)
+                    {
+                        return loaded.Favorites;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                return favorites;
+            }
+
+            return favorites;
+        }
+
+        private static IEnumerable<string> GetAccountIds(string steamPath)
+        {
+            HashSet<string> accountIds = new();
+
+            foreach (var accountId in GetMostRecentLoginAccountIds(steamPath))
+            {
+                if (accountIds.Add(accountId) == true)
+                {
+                    yield return accountId;
+                }
+            }
+
+            string userdataPath = Path.Combine(steamPath, "userdata");
+            if (Directory.Exists(userdataPath) == false)
+            {
+                yield break;
+            }
+
+            foreach (string path in Directory.EnumerateDirectories(userdataPath)
+                         .OrderByDescending(Directory.GetLastWriteTimeUtc))
+            {
+                string accountId = Path.GetFileName(path);
+                if (uint.TryParse(accountId, NumberStyles.Integer, CultureInfo.InvariantCulture, out _) == false)
+                {
+                    continue;
+                }
+
+                if (accountIds.Add(accountId) == true)
+                {
+                    yield return accountId;
+                }
+            }
+        }
+
+        private static IEnumerable<string> GetMostRecentLoginAccountIds(string steamPath)
+        {
+            string path = Path.Combine(steamPath, "config", "loginusers.vdf");
+            if (File.Exists(path) == false)
+            {
+                yield break;
+            }
+
+            string text;
+            using (var input = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (StreamReader streamReader = new(input, Encoding.UTF8, true))
+            {
+                text = streamReader.ReadToEnd();
+            }
+
+            VdfTokenReader tokenReader = new(text);
+            while (tokenReader.TryRead(out string steamId) == true)
+            {
+                if (ulong.TryParse(steamId, NumberStyles.Integer, CultureInfo.InvariantCulture, out ulong steamId64) == false)
+                {
+                    continue;
+                }
+
+                if (tokenReader.TryRead(out string next) == false || next != "{")
+                {
+                    continue;
+                }
+
+                if (ReadLoginUserBlock(tokenReader) == false)
+                {
+                    continue;
+                }
+
+                uint accountId = (uint)(steamId64 & 0xFFFFFFFF);
+                yield return accountId.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        private static bool ReadLoginUserBlock(VdfTokenReader reader)
+        {
+            bool mostRecent = false;
+            int depth = 1;
+            while (depth > 0 && reader.TryRead(out string token) == true)
+            {
+                if (token == "{")
+                {
+                    depth++;
+                    continue;
+                }
+
+                if (token == "}")
+                {
+                    depth--;
+                    continue;
+                }
+
+                if (depth != 1 || string.Compare(token, "MostRecent", StringComparison.InvariantCultureIgnoreCase) != 0)
+                {
+                    continue;
+                }
+
+                if (reader.TryRead(out string value) == true)
+                {
+                    mostRecent = value == "1";
+                }
+            }
+
+            return mostRecent;
+        }
+
+        private static LoadResult LoadFromCloudStorage(string path)
+        {
+            HashSet<uint> favorites = new();
+            if (File.Exists(path) == false)
+            {
+                return LoadResult.CreateNotFound(favorites);
+            }
+
+            string text;
+            using (var input = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (StreamReader reader = new(input, Encoding.UTF8, true))
+            {
+                text = reader.ReadToEnd();
+            }
+
+            JsonValue root = JsonParser.Parse(text);
+            if (root?.Array == null)
+            {
+                return LoadResult.CreateFound(favorites);
+            }
+
+            foreach (var entry in root.Array)
+            {
+                if (entry.Array == null || entry.Array.Count < 2)
+                {
+                    continue;
+                }
+
+                if (string.Compare(entry.Array[0].String, FavoritesKey, StringComparison.InvariantCultureIgnoreCase) != 0)
+                {
+                    continue;
+                }
+
+                var value = entry.Array[1].GetObjectValue("value");
+                if (value?.String == null)
+                {
+                    return LoadResult.CreateFound(favorites);
+                }
+
+                return LoadResult.CreateFound(LoadFromCollection(value.String));
+            }
+
+            return LoadResult.CreateFound(favorites);
+        }
+
+        private static HashSet<uint> LoadFromCollection(string text)
+        {
+            HashSet<uint> favorites = new();
+
+            JsonValue root = JsonParser.Parse(text);
+            var added = root?.GetObjectValue("added");
+            if (added?.Array == null)
+            {
+                return favorites;
+            }
+
+            foreach (var value in added.Array)
+            {
+                if (value.Number.HasValue == false)
+                {
+                    continue;
+                }
+
+                double number = value.Number.Value;
+                if (number < uint.MinValue ||
+                    number > uint.MaxValue ||
+                    Math.Truncate(number) != number)
+                {
+                    continue;
+                }
+
+                favorites.Add((uint)number);
+            }
+
+            return favorites;
+        }
+
+        private readonly struct LoadResult
+        {
+            public readonly bool Found;
+            public readonly HashSet<uint> Favorites;
+
+            private LoadResult(bool found, HashSet<uint> favorites)
+            {
+                this.Found = found;
+                this.Favorites = favorites;
+            }
+
+            public static LoadResult CreateFound(HashSet<uint> favorites)
+            {
+                return new(true, favorites);
+            }
+
+            public static LoadResult CreateNotFound(HashSet<uint> favorites)
+            {
+                return new(false, favorites);
+            }
+        }
+
+        private sealed class JsonValue
+        {
+            public string String;
+            public double? Number;
+            public List<JsonValue> Array;
+            public Dictionary<string, JsonValue> Object;
+
+            public JsonValue GetObjectValue(string key)
+            {
+                if (this.Object == null)
+                {
+                    return null;
+                }
+
+                return this.Object.TryGetValue(key, out var value) == true
+                    ? value
+                    : null;
+            }
+        }
+
+        private sealed class JsonParser
+        {
+            private readonly string _Text;
+            private int _Offset;
+
+            private JsonParser(string text)
+            {
+                this._Text = text ?? "";
+            }
+
+            public static JsonValue Parse(string text)
+            {
+                return new JsonParser(text).ParseValue();
+            }
+
+            private JsonValue ParseValue()
+            {
+                this.SkipWhitespace();
+                if (this._Offset >= this._Text.Length)
+                {
+                    return null;
+                }
+
+                char c = this._Text[this._Offset];
+                switch (c)
+                {
+                    case '"':
+                    {
+                        return new()
+                        {
+                            String = this.ParseString(),
+                        };
+                    }
+
+                    case '[':
+                    {
+                        return this.ParseArray();
+                    }
+
+                    case '{':
+                    {
+                        return this.ParseObject();
+                    }
+
+                    default:
+                    {
+                        if (c == '-' || char.IsDigit(c) == true)
+                        {
+                            return this.ParseNumber();
+                        }
+
+                        this.ParseLiteral();
+                        return new();
+                    }
+                }
+            }
+
+            private JsonValue ParseArray()
+            {
+                JsonValue value = new()
+                {
+                    Array = new(),
+                };
+
+                this._Offset++;
+                while (true)
+                {
+                    this.SkipWhitespace();
+                    if (this.TryRead(']') == true)
+                    {
+                        return value;
+                    }
+
+                    value.Array.Add(this.ParseValue());
+                    this.SkipWhitespace();
+
+                    if (this.TryRead(',') == true)
+                    {
+                        continue;
+                    }
+
+                    this.TryRead(']');
+                    return value;
+                }
+            }
+
+            private JsonValue ParseObject()
+            {
+                JsonValue value = new()
+                {
+                    Object = new(StringComparer.InvariantCultureIgnoreCase),
+                };
+
+                this._Offset++;
+                while (true)
+                {
+                    this.SkipWhitespace();
+                    if (this.TryRead('}') == true)
+                    {
+                        return value;
+                    }
+
+                    if (this._Offset >= this._Text.Length || this._Text[this._Offset] != '"')
+                    {
+                        return value;
+                    }
+
+                    string key = this.ParseString();
+                    this.SkipWhitespace();
+                    if (this.TryRead(':') == false)
+                    {
+                        return value;
+                    }
+
+                    value.Object[key] = this.ParseValue();
+                    this.SkipWhitespace();
+
+                    if (this.TryRead(',') == true)
+                    {
+                        continue;
+                    }
+
+                    this.TryRead('}');
+                    return value;
+                }
+            }
+
+            private JsonValue ParseNumber()
+            {
+                int start = this._Offset;
+                if (this._Text[this._Offset] == '-')
+                {
+                    this._Offset++;
+                }
+
+                while (this._Offset < this._Text.Length && char.IsDigit(this._Text[this._Offset]) == true)
+                {
+                    this._Offset++;
+                }
+
+                if (this._Offset < this._Text.Length && this._Text[this._Offset] == '.')
+                {
+                    this._Offset++;
+                    while (this._Offset < this._Text.Length && char.IsDigit(this._Text[this._Offset]) == true)
+                    {
+                        this._Offset++;
+                    }
+                }
+
+                string text = this._Text.Substring(start, this._Offset - start);
+                return new()
+                {
+                    Number = double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double number) == true
+                        ? number
+                        : null,
+                };
+            }
+
+            private string ParseString()
+            {
+                StringBuilder builder = new();
+                this._Offset++;
+
+                while (this._Offset < this._Text.Length)
+                {
+                    char c = this._Text[this._Offset++];
+                    if (c == '"')
+                    {
+                        break;
+                    }
+
+                    if (c != '\\' || this._Offset >= this._Text.Length)
+                    {
+                        builder.Append(c);
+                        continue;
+                    }
+
+                    c = this._Text[this._Offset++];
+                    switch (c)
+                    {
+                        case '"':
+                        case '\\':
+                        case '/':
+                        {
+                            builder.Append(c);
+                            break;
+                        }
+
+                        case 'b':
+                        {
+                            builder.Append('\b');
+                            break;
+                        }
+
+                        case 'f':
+                        {
+                            builder.Append('\f');
+                            break;
+                        }
+
+                        case 'n':
+                        {
+                            builder.Append('\n');
+                            break;
+                        }
+
+                        case 'r':
+                        {
+                            builder.Append('\r');
+                            break;
+                        }
+
+                        case 't':
+                        {
+                            builder.Append('\t');
+                            break;
+                        }
+
+                        case 'u' when this._Offset + 4 <= this._Text.Length:
+                        {
+                            string hex = this._Text.Substring(this._Offset, 4);
+                            if (ushort.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ushort code) == true)
+                            {
+                                builder.Append((char)code);
+                                this._Offset += 4;
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                return builder.ToString();
+            }
+
+            private void ParseLiteral()
+            {
+                while (this._Offset < this._Text.Length &&
+                       char.IsLetter(this._Text[this._Offset]) == true)
+                {
+                    this._Offset++;
+                }
+            }
+
+            private bool TryRead(char expected)
+            {
+                if (this._Offset >= this._Text.Length ||
+                    this._Text[this._Offset] != expected)
+                {
+                    return false;
+                }
+
+                this._Offset++;
+                return true;
+            }
+
+            private void SkipWhitespace()
+            {
+                while (this._Offset < this._Text.Length &&
+                       char.IsWhiteSpace(this._Text[this._Offset]) == true)
+                {
+                    this._Offset++;
+                }
+            }
+        }
+
+        private sealed class VdfTokenReader
+        {
+            private readonly string _Text;
+            private int _Offset;
+
+            public VdfTokenReader(string text)
+            {
+                this._Text = text ?? "";
+            }
+
+            public bool TryRead(out string token)
+            {
+                token = null;
+                this.SkipWhitespace();
+                if (this._Offset >= this._Text.Length)
+                {
+                    return false;
+                }
+
+                char c = this._Text[this._Offset++];
+                if (c == '{' || c == '}')
+                {
+                    token = c.ToString();
+                    return true;
+                }
+
+                if (c == '"')
+                {
+                    StringBuilder builder = new();
+                    while (this._Offset < this._Text.Length)
+                    {
+                        c = this._Text[this._Offset++];
+                        if (c == '"')
+                        {
+                            break;
+                        }
+
+                        if (c == '\\' && this._Offset < this._Text.Length)
+                        {
+                            c = this._Text[this._Offset++];
+                        }
+
+                        builder.Append(c);
+                    }
+
+                    token = builder.ToString();
+                    return true;
+                }
+
+                int start = this._Offset - 1;
+                while (this._Offset < this._Text.Length)
+                {
+                    c = this._Text[this._Offset];
+                    if (char.IsWhiteSpace(c) == true || c == '{' || c == '}')
+                    {
+                        break;
+                    }
+
+                    this._Offset++;
+                }
+
+                token = this._Text.Substring(start, this._Offset - start);
+                return true;
+            }
+
+            private void SkipWhitespace()
+            {
+                while (this._Offset < this._Text.Length &&
+                       char.IsWhiteSpace(this._Text[this._Offset]) == true)
+                {
+                    this._Offset++;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This PR adds a "Show only favourites" filter to the SAM.Picker games list, letting users quickly see their favourites - as requested by issue #609. 

# Changes
Added SteamLibraryFavourites, which:
  - locates the active steam account
  -  reads steam cloud storage data
  - extracts the "user-collections.favorite" collection
 Used this to create a filter
 
 All previous behaviour is untouched, and if favourites data is unavailable it shows all games as before.
 
 This is my first PR on a public repo, any advice / criticism is appreciated!
 