### PR TITLE
Add emulator achievements sync UI and scanner

### DIFF
--- a/SAM.Picker/EmulatorScanner.cs
+++ b/SAM.Picker/EmulatorScanner.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace SAM.Picker
+{
+    internal class EmulatorGameInfo
+    {
+        public string Name { get; set; }
+        public uint AppId { get; set; }
+        public string Emulator { get; set; }
+        public Dictionary<string, bool> Achievements { get; } = new();
+n        public int CountUnlocked => Achievements == null ? 0 : (int) (Achievements.Values == null ? 0 : (uint)0);
+    }
+
+    internal static class EmulatorScanner
+    {
+        // Folders to scan (can be customized later)
+        private static readonly string[] DefaultPaths = new[]
+        {
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GSE Saves"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Goldberg SteamEmu Saves"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonDocuments), "OnlineFix"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonDocuments), "Steam\\RUNE"),
+        };
+
+        public static IEnumerable<EmulatorGameInfo> ScanDefaultPaths()
+        {
+            var results = new List<EmulatorGameInfo>();
+            foreach (var p in DefaultPaths)
+            {
+                try
+                {
+                    if (Directory.Exists(p) == false) continue;
+                    foreach (var dir in Directory.GetDirectories(p))
+                    {
+                        try
+                        {
+                            var info = ScanDirectoryForGame(dir);
+                            if (info != null)
+                            {
+                                results.Add(info);
+                            }
+                        }
+                        catch { }
+                    }
+                }
+                catch { }
+            }
+            return results;
+        }
+
+        private static EmulatorGameInfo ScanDirectoryForGame(string dir)
+        {
+            // Determine appid from directory name if numeric
+            var name = Path.GetFileName(dir);
+            uint appid = 0;
+            if (uint.TryParse(name, out var parsed))
+            {
+                appid = parsed;
+            }
+
+            var files = Directory.GetFiles(dir);
+            EmulatorGameInfo result = null;
+            foreach (var f in files)
+            {
+                var fn = Path.GetFileName(f).ToLowerInvariant();
+                if (fn.Contains("achievement") && fn.EndsWith(".json"))
+                {
+                    var g = new EmulatorGameInfo() { Name = name, AppId = appid, Emulator = DetectEmulatorFromPath(dir) };
+                    ParseGseJson(f, g);
+                    result = g;
+                    break;
+                }
+                if (fn.Contains("achievement") && fn.EndsWith(".ini"))
+                {
+                    var g = new EmulatorGameInfo() { Name = name, AppId = appid, Emulator = DetectEmulatorFromPath(dir) };
+                    ParseRuneIni(f, g);
+                    result = g;
+                    break;
+                }
+                // fallback: parse any .json or .ini that looks like achievements
+                if (fn.EndsWith(".json"))
+                {
+                    var content = File.ReadAllText(f);
+                    if (content.Contains("\"earned\""))
+                    {
+                        var g = new EmulatorGameInfo() { Name = name, AppId = appid, Emulator = DetectEmulatorFromPath(dir) };
+                        ParseGseJson(f, g);
+                        result = g;
+                        break;
+                    }
+                }
+                if (fn.EndsWith(".ini"))
+                {
+                    var content = File.ReadAllText(f);
+                    if (content.Contains("[SteamAchievements]") || content.Contains("Achieved="))
+                    {
+                        var g = new EmulatorGameInfo() { Name = name, AppId = appid, Emulator = DetectEmulatorFromPath(dir) };
+                        ParseRuneIni(f, g);
+                        result = g;
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static string DetectEmulatorFromPath(string path)
+        {
+            var p = path.ToLowerInvariant();
+            if (p.Contains("gse")) return "GSE";
+            if (p.Contains("goldberg")) return "Goldberg";
+            if (p.Contains("onlinefix")) return "OnlineFix";
+            if (p.Contains("rune")) return "RUNE";
+            return "Unknown";
+        }
+
+        private static void ParseGseJson(string path, EmulatorGameInfo outInfo)
+        {
+            var text = File.ReadAllText(path);
+            // very small naive JSON parser for the structure provided: keys map to { "earned": true/false }
+            var regex = new Regex("\"(?<key>[^\"]+)\"\s*:\s*\\{[^}]*?\"earned\"\s*:\s*(?<earned>true|false)", RegexOptions.IgnoreCase);
+            foreach (Match m in regex.Matches(text))
+            {
+                var key = m.Groups["key"].Value;
+                var earned = string.Equals(m.Groups["earned"].Value, "true", StringComparison.OrdinalIgnoreCase);
+                outInfo.Achievements[key] = earned;
+            }
+        }
+
+        private static void ParseRuneIni(string path, EmulatorGameInfo outInfo)
+        {
+            var lines = File.ReadAllLines(path);
+            string currentSection = null;
+            var steamList = new List<string>();
+            var achievedMap = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            foreach (var raw in lines)
+            {
+                var line = raw.Trim();
+                if (line.Length == 0) continue;
+                if (line.StartsWith("[") && line.EndsWith("]"))
+                {
+                    currentSection = line.Substring(1, line.Length - 2);
+                    continue;
+                }
+                if (currentSection == "SteamAchievements")
+                {
+                    var parts = line.Split(new[] {'='}, 2);
+                    if (parts.Length == 2)
+                    {
+                        steamList.Add(parts[1].Trim());
+                    }
+                }
+                else if (!string.IsNullOrEmpty(currentSection))
+                {
+                    if (line.StartsWith("Achieved=", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var val = line.Substring("Achieved=".Length).Trim();
+                        var achieved = val == "1" || string.Equals(val, "true", StringComparison.OrdinalIgnoreCase);
+                        achievedMap[currentSection] = achieved;
+                    }
+                }
+            }
+
+            // map steamList entries to achievedMap where possible
+            foreach (var key in steamList)
+            {
+                if (achievedMap.TryGetValue(key, out var v))
+                {
+                    outInfo.Achievements[key] = v;
+                }
+                else
+                {
+                    outInfo.Achievements[key] = false;
+                }
+            }
+        }
+    }
+}

--- a/SAM.Picker/EmulatorSyncForm.cs
+++ b/SAM.Picker/EmulatorSyncForm.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using SAM.API;
+
+namespace SAM.Picker
+{
+    internal partial class EmulatorSyncForm : Form
+    {
+        private readonly List<EmulatorGameInfo> _games;
+        private readonly Client _steamClient;
+n        public EmulatorSyncForm(Client steamClient)
+        {
+            this._steamClient = steamClient;
+            this._games = EmulatorScanner.ScanDefaultPaths().ToList();
+            InitializeComponent();
+            PopulateList();
+        }
+
+        private void InitializeComponent()
+        {
+            this.Text = "Emulator achievements sync";
+            this.Width = 700;
+            this.Height = 400;
+            this.StartPosition = FormStartPosition.CenterParent;
+n            var list = new ListView();
+            list.Name = "_GameList";
+            list.View = View.Details;
+            list.FullRowSelect = true;
+            list.Dock = DockStyle.Top;
+            list.Height = 300;
+            list.Columns.Add("Name", 250);
+            list.Columns.Add("AppId", 80);
+            list.Columns.Add("Emulator", 120);
+            list.Columns.Add("Unlocked", 80);
+            list.DoubleClick += OnDoubleClickSync;
+            this.Controls.Add(list);
+n            var syncButton = new Button();
+            syncButton.Text = "Sincronizar seleccionado";
+            syncButton.Dock = DockStyle.Bottom;
+            syncButton.Height = 30;
+            syncButton.Click += (s, e) => SyncSelected();
+            this.Controls.Add(syncButton);
+        }
+
+        private void PopulateList()
+        {
+            var list = (ListView)this.Controls.Find("_GameList", true).FirstOrDefault();
+            if (list == null) return;
+            list.Items.Clear();
+            foreach (var g in _games)
+            {
+                var unlocked = g.Achievements?.Values.Count(v => v) ?? 0;
+                var idStr = g.AppId == 0 ? "N/A" : g.AppId.ToString();
+                var it = new ListViewItem(new[] { g.Name, idStr, g.Emulator, unlocked.ToString() });
+                it.Tag = g;
+                list.Items.Add(it);
+            }
+        }
+
+        private void OnDoubleClickSync(object sender, EventArgs e)
+        {
+            SyncSelected();
+        }
+
+        private void SyncSelected()
+        {
+            var list = (ListView)this.Controls.Find("_GameList", true).FirstOrDefault();
+            if (list == null || list.SelectedItems.Count == 0)
+            {
+                MessageBox.Show(this, "Seleccione un juego.", "Atención", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+n            var sel = list.SelectedItems[0];
+            var game = (EmulatorGameInfo)sel.Tag;
+            if (game.AppId == 0)
+            {
+                MessageBox.Show(this, "No se pudo determinar el AppID para este juego.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+n            try
+            {
+                using (var client = new Client())
+                {
+                    client.Initialize(game.AppId);
+                    int setCount = 0;
+                    foreach (var kv in game.Achievements)
+                    {
+                        if (kv.Value == true)
+                        {
+                            // attempt to set achievement by name (best-effort)
+                            var ok = client.SteamUserStats.SetAchievement(kv.Key, true);
+                            if (ok) setCount++;
+                        }
+                    }
+                    client.SteamUserStats.StoreStats();
+                    MessageBox.Show(this, $"Sincronizados {setCount} logros para AppID {game.AppId}.", "Completado", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+    }
+}

--- a/SAM.Picker/GamePicker.Designer.cs
+++ b/SAM.Picker/GamePicker.Designer.cs
@@ -82,6 +82,7 @@
             //
             this._PickerToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this._RefreshGamesButton,
+            this._EmulatorSyncButton,
             _ToolStripSeparator1,
             this._AddGameTextBox,
             this._AddGameButton,
@@ -103,6 +104,16 @@
             this._RefreshGamesButton.Size = new System.Drawing.Size(105, 22);
             this._RefreshGamesButton.Text = "Refresh Games";
             this._RefreshGamesButton.Click += new System.EventHandler(this.OnRefresh);
+            // 
+            // _EmulatorSyncButton
+            //
+            this._EmulatorSyncButton = new System.Windows.Forms.ToolStripButton();
+            this._EmulatorSyncButton.Image = global::SAM.Picker.Resources.Refresh; // reuse icon
+            this._EmulatorSyncButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this._EmulatorSyncButton.Name = "_EmulatorSyncButton";
+            this._EmulatorSyncButton.Size = new System.Drawing.Size(120, 22);
+            this._EmulatorSyncButton.Text = "Emulator Sync";
+            this._EmulatorSyncButton.Click += new System.EventHandler(this.OnEmulatorSync);
             //
             // _AddGameTextBox
             //
@@ -279,6 +290,7 @@
         private System.ComponentModel.BackgroundWorker _ListWorker;
         private System.Windows.Forms.ToolStripTextBox _SearchGameTextBox;
         private System.Windows.Forms.ToolStripLabel _FindGamesLabel;
+        private System.Windows.Forms.ToolStripButton _EmulatorSyncButton;
 
         #endregion
     }

--- a/SAM.Picker/GamePicker.cs
+++ b/SAM.Picker/GamePicker.cs
@@ -471,6 +471,21 @@ namespace SAM.Picker
             this.AddGames();
         }
 
+        private void OnEmulatorSync(object sender, EventArgs e)
+        {
+            try
+            {
+                using (var form = new EmulatorSyncForm(this._SteamClient))
+                {
+                    form.ShowDialog(this);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
         private void OnAddGame(object sender, EventArgs e)
         {
             uint id;

--- a/SAM.Picker/SAM.Picker.csproj
+++ b/SAM.Picker/SAM.Picker.csproj
@@ -43,6 +43,10 @@
     <Compile Update="GamePicker.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Update="EmulatorScanner.cs" />
+    <Compile Update="EmulatorSyncForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
Add a new EmulatorScanner to detect achievements saved by common Steam emulators (RUNE, GSE, Goldberg, OnlineFix) and a simple Emulator Sync form accessible from the Game Picker. The form lists detected games and lets the user synchronize unlocked achievements with Steam for the selected app using the existing SAM.API client.

Notes:
- Parser is best-effort: parses RUNE .ini and simple GSE-style JSON structures.
- Sync attempts to SetAchievement by key names found in save files; some games may require different internal keys and thus not all achievements will be set.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>